### PR TITLE
Update footer.html

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,7 +1,7 @@
 <footer id="site-footer" class="o-footer o-footer--theme-dark" data-o-component="o-footer" data-o-footer--js="">
 	<div class="n-syn-footer__contact">
 		<div class="o-footer__container">
-			Any questions? Contact Us <a class="n-syn-footer__space" data-trackable="contact-phone-uk" href="tel: +44 (0)20 7873 4001">+44 (0)20 7873 4001</a> or <a data-trackable="contact-phone-us" href="tel: +1 877 843 3399">+1 877 843 3399</a> <a class="n-syn-footer__space" data-trackable="contact-email" href="mailto:b2b.customersupport@ft.com?subject=Republishing%20enquiry">B2B.CustomerSupport@ft.com</a>
+			Any questions? Contact Us <a class="n-syn-footer__space" data-trackable="contact-phone-uk" href="tel: +44 (0)20 7873 4001">+44 (0)20 7873 4001</a> or <a data-trackable="contact-phone-us" href="tel: +1 877 843 3399">+1 877 843 3399</a> <a class="n-syn-footer__space" data-trackable="contact-email" href="mailto:customer.support@ft.com?subject=Republishing%20enquiry">customer.support@ft.com</a>
 		</div>
 	</div>
 	<div class="o-footer__container">
@@ -12,7 +12,7 @@
 				<li><a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a></li>
 				<li><a href="http://help.ft.com/help/legal-privacy/cookies/">Cookies</a></li>
 				<li><a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a></li>
-				<li><a href="http://help.ft.com/help/">Help</a></li>
+				<li><a href="https://help.ft.com/help/b2b-support/republishing-service/">Help</a></li>
 			</ul>
 		</div>
 		<div class="o-footer__copyright" role="contentinfo">


### PR DESCRIPTION
According to card #317: Update Help URL & contact email address in footer

CONDITIONS OF ACCEPTANCE
WHEN I click the "Help" link in the Republishing Tool footer THEN the following page is displayed: https://help.ft.com/help/b2b-support/republishing-service/

Support email address in footer to be: "customer.support@ft.com"